### PR TITLE
Add support for custom css

### DIFF
--- a/templates/partials/head.html.twig
+++ b/templates/partials/head.html.twig
@@ -13,6 +13,7 @@
 {% do assets.add('theme://fonts/font-awesome/css/font-awesome.min.css', 101) %}
 {% do assets.add('theme://css/style.css', 101) %}
 {% do assets.add('theme://css/mobile-menu.css', 101) %}
+{% do assets.add('theme://css/custom.css', 101) %}
  {{ assets.css() }}
 {% endblock %}
 


### PR DESCRIPTION
This change adds a line to the head template that will look for custom.css
and load this if provided. This is useful for those wanting to extend the
theme without having their custom styles overridden by an update to the base
theme.

**Test-information:**

Added a custom.css stylesheet to a theme extending x-corporation and
observed that my custom styles were applied.