### PR TITLE
smoothscroll.js is no longer necessary

### DIFF
--- a/templates/partials/head.html.twig
+++ b/templates/partials/head.html.twig
@@ -28,7 +28,6 @@
     {% endif %}
 
     {% do assets.addJs('jquery', 101) %}
-    {% do assets.add('theme://js/smoothscroll.js') %}
     {% do assets.add('theme://js/mobile-menu.js') %}
     {% do assets.add('theme://js/flexSlider/jquery.flexslider-min.js') %}
     {% do assets.add('theme://js/scripts.js') %}


### PR DESCRIPTION
The smoothscroll.js library is buggy, no longer necessary and degrades performance. See https://www.chromestatus.com/feature/5749447073988608