### PR TITLE
Improve mobile menu behaviour when page scrolled

### DIFF
--- a/css/mobile-menu.css
+++ b/css/mobile-menu.css
@@ -69,7 +69,7 @@
     }
 
 .slide-along .uc-offcanvas-container {
-    position           : fixed;
+    position           : absolute;
     top                : 0;
     left               : 0;
     visibility         : hidden;
@@ -82,7 +82,6 @@
     -moz-transition    : all 400ms;
     -o-transition      : all 400ms;
     transition         : all 400ms;
-    z-index            : 2;
     }
 
 .uc-offcanvas-container > div {
@@ -153,6 +152,8 @@
     -ms-transition     : -webkit-transform 400ms;
     -o-transition      : -webkit-transform 400ms;
     transition         : transform 400ms;
+    position           : fixed;
+    z-index            : 2;
     }
 
 .slide-along .uc-offcanvas-container::after {

--- a/css/mobile-menu.css
+++ b/css/mobile-menu.css
@@ -69,7 +69,7 @@
     }
 
 .slide-along .uc-offcanvas-container {
-    position           : absolute;
+    position           : fixed;
     top                : 0;
     left               : 0;
     visibility         : hidden;
@@ -82,6 +82,7 @@
     -moz-transition    : all 400ms;
     -o-transition      : all 400ms;
     transition         : all 400ms;
+    z-index            : 2;
     }
 
 .uc-offcanvas-container > div {

--- a/css/style.css
+++ b/css/style.css
@@ -282,7 +282,7 @@ BACK TO TOP
     color       : #31aae2;
     cursor      : pointer;
     display     : none;
-    z-index     : 9999;
+    z-index     : 1;
     width       : 30px;
     height      : 30px;
     border      : 2px solid #31aae2;


### PR DESCRIPTION
If you scroll the page, the mobile menu probably shouldn't get
pushed up by the footer. This makes it awkward to select the first
item in the menu.

This change addresses this by giving the menu container a fixed
position and setting an appropriate z-index.

See issue #31.

**Test-information:**

Did a quick test on a personal project.

Previously, the mobile menu would get pushed up by the footer.
After this change it is fixed to the height of the viewport.

The menu still scrolls when items overflow.